### PR TITLE
bump mule-java-module version to 1.2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 		<dependency>
 			<groupId>org.mule.module</groupId>
 			<artifactId>mule-java-module</artifactId>
-			<version>1.2.9</version>
+			<version>1.2.10</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
As org.mule.module:mule-java-module:jar:mule-plugin:1.2.9:compile pulls in org.springframework:spring-core:jar:5.3.9:compile and spring-core-5.3.9.jar has the known vulnerabilty CVE-2022-22965(9.8) it should be updated to  mule-plugin:1.2.10  (which includes spring 5.3.21 (which has another but hopefully less bad vulnerability CVE-2023-20861))